### PR TITLE
Fixing #9

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,6 +9,12 @@ function resolveAuthLevel(schema, options, doc) {
     if (options.authLevel) {
       authLevels = _.castArray(options.authLevel);
     } else if (typeof schema.getAuthLevel === 'function') {
+      if (!options.authPayload) {
+        throw new Error('An `authPayload` must exist with a `getAuthLevel` method.');
+      }
+      if (!doc) {
+        throw new Error('This type of query is not compatible with using a getAuthLevel method.');
+      }
       authLevels = _.castArray(schema.getAuthLevel(options.authPayload, doc));
     }
   }

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -119,10 +119,6 @@ module.exports = {
     },
     'from document getAuthLevel': (test) => {
       test.deepEqual(
-        resolveAuthLevel(goodSchema, {}, { foo: 1 }),
-        ['defaults'],
-      );
-      test.deepEqual(
         resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'admin' } }, { foo: 1 }),
         ['admin', 'defaults'],
       );
@@ -134,10 +130,26 @@ module.exports = {
         resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'self' }, authLevel: 'admin' }, { foo: 1 }),
         ['admin', 'defaults'],
       );
-      test.deepEqual(
-        resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'self' } }),
-        ['self', 'defaults'],
-      );
+      test.done();
+    },
+    'missing authPayload': (test) => {
+      test.expect(1);
+      try {
+        resolveAuthLevel(goodSchema, {}, {});
+      } catch(err) {
+        test.ok(err);
+      }
+
+      test.done();
+    },
+    'missing doc': (test) => {
+      test.expect(1);
+      try {
+        resolveAuthLevel(goodSchema, { authPayload: 'foo' }, false);
+      } catch(err) {
+        test.ok(err);
+      }
+
       test.done();
     },
   },
@@ -198,16 +210,6 @@ module.exports = {
       hasPermission(bareBonesSchema, {}, 'create'),
       false,
       'should return false when no permissions exist',
-    );
-    test.equal(
-      hasPermission(goodSchema, {}, 'create'),
-      false,
-      'default write permission not respected when no authLevel specified',
-    );
-    test.equal(
-      hasPermission(goodSchema, {}, 'create'),
-      false,
-      'should return false when no permission has been set for the action',
     );
     test.equal(
       hasPermission(goodSchema, { authLevel: 'admin' }, 'create'),


### PR DESCRIPTION
This diff makes it an error to not pass `authPayload` when your schema has a `getAuthLevel` method. It is also an error to have a getAuthLevel method, but to use `Model.update`, which doesn't make the `doc` available at query time.