### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var userSchema = new mongoose.Schema({
  */
 userSchema.permissions = {
   defaults: {
-    read: [email', 'first_name', 'last_name', 'avatar']
+    read: ['email', 'first_name', 'last_name', 'avatar']
   },
   admin: {
     read: ['status'],


### PR DESCRIPTION
This was making the snippet in the markdown preview all red.