### PR TITLE
Finish async

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# mongoose-authorization
-
-[![Build Status](https://travis-ci.org/352Media/mongoose-authorization.svg?branch=dev)](https://travis-ci.org/352Media/mongoose-authorization)
+# mongoose-authz
 
 This plugin allows you to define a custom authorization scheme on your mongoose models.
 
-`npm install --save mongoose-authorization`
+`npm install --save mongoose-authz`
 
 
 ## Getting Started
@@ -12,7 +10,7 @@ This plugin allows you to define a custom authorization scheme on your mongoose 
 ```javascript
 'use strict';
 var mongoose = require('mongoose');
-var authz = require('mongoose-authorization');
+var authz = require('mongoose-authz');
 
 var userSchema = new mongoose.Schema({
   email: {

--- a/index.js
+++ b/index.js
@@ -10,69 +10,77 @@ const {
 const PermissionDeniedError = require('./lib/PermissionDeniedError');
 
 module.exports = (schema) => {
-  function save(doc, options, next) {
-    if (doc.isNew && !hasPermission(schema, options, 'create', doc)) {
-      return next(new PermissionDeniedError('create'));
+  async function save(doc, options, next) {
+    if (doc.isNew && !await hasPermission(schema, options, 'create', doc)) {
+      next(new PermissionDeniedError('create'));
+      return;
     }
 
-    const authorizedFields = getAuthorizedFields(schema, options, 'write', doc);
+    const authorizedFields = await getAuthorizedFields(schema, options, 'write', doc);
     const modifiedPaths = doc.modifiedPaths();
     const discrepancies = _.difference(modifiedPaths, authorizedFields);
 
     if (discrepancies.length > 0) {
-      return next(new PermissionDeniedError('write', discrepancies));
+      next(new PermissionDeniedError('write', discrepancies));
+      return;
     }
 
-    return next();
+    next();
   }
 
-  function removeQuery(query, next) {
-    if (!hasPermission(schema, query.options, 'remove')) {
-      return next(new PermissionDeniedError('remove'));
+  async function removeQuery(query, next) {
+    if (!await hasPermission(schema, query.options, 'remove')) {
+      next(new PermissionDeniedError('remove'));
+      return;
     }
 
-    return next();
+    next();
+    return;
   }
 
-  function removeDoc(doc, options, next) {
-    if (!hasPermission(schema, options, 'remove', doc)) {
-      return next(new PermissionDeniedError('remove'));
+  async function removeDoc(doc, options, next) {
+    if (!await hasPermission(schema, options, 'remove', doc)) {
+      next(new PermissionDeniedError('remove'));
+      return;
     }
 
-    return next();
+    next();
+    return;
   }
 
-  function find(query, docs, next) {
-    const sanitizedResult = sanitizeDocumentList(schema, query.options, docs);
+  async function find(query, docs, next) {
+    const sanitizedResult = await sanitizeDocumentList(schema, query.options, docs);
 
-    return next(null, sanitizedResult);
+    next(null, sanitizedResult);
   }
 
-  function update(query, next) {
+  async function update(query, next) {
     // If this is an upsert, you'll need the create permission
     // TODO add some tests for the upset case
     if (
       query.options
       && query.options.upsert
-      && !hasPermission(schema, query.options, 'create')
+      && !await hasPermission(schema, query.options, 'create')
     ) {
-      return next(new PermissionDeniedError('create'));
+      next(new PermissionDeniedError('create'));
+      return;
     }
 
-    const authorizedFields = getAuthorizedFields(schema, query.options, 'write');
+    const authorizedFields = await getAuthorizedFields(schema, query.options, 'write');
 
     // check to see if the group is trying to update a field it does not have permission to
     const modifiedPaths = getUpdatePaths(query._update);
     const discrepancies = _.difference(modifiedPaths, authorizedFields);
     if (discrepancies.length > 0) {
-      return next(new PermissionDeniedError('write', discrepancies));
+      next(new PermissionDeniedError('write', discrepancies));
+      return;
     }
 
     // TODO handle the overwrite option
     // TODO handle Model.updateMany
 
     // Detect which fields can be returned if 'new: true' is set
-    const authorizedReturnFields = getAuthorizedFields(schema, query.options, 'read');
+    const authorizedReturnFields = await getAuthorizedFields(schema, query.options, 'read');
 
     // create a sanitizedReturnFields object that will be used to return only the fields that a
     // group has access to read
@@ -84,7 +92,7 @@ module.exports = (schema) => {
     });
     query._fields = sanitizedReturnFields;
 
-    return next();
+    next();
   }
 
   // Find paths with permissioned schemas and store those so deep checks can be done
@@ -98,34 +106,34 @@ module.exports = (schema) => {
   });
 
   schema.pre('findOneAndRemove', function preFindOneAndRemove(next) {
-    if (authIsDisabled(this.options)) { return next(); }
-    return removeQuery(this, next);
+    if (authIsDisabled(this.options)) { next(); return; }
+    removeQuery(this, next);
   });
   // TODO, WTF, how to prevent someone from Model.find().remove().exec(); That doesn't
   // fire any remove hooks. Does it fire a find hook?
   schema.pre('remove', function preRemove(next, options) {
-    if (authIsDisabled(options)) { return next(); }
-    return removeDoc(this, options, next);
+    if (authIsDisabled(options)) { next(); return; }
+    removeDoc(this, options, next);
   });
   schema.pre('save', function preSave(next, options) {
-    if (authIsDisabled(options)) { return next(); }
-    return save(this, options, next);
+    if (authIsDisabled(options)) { next(); return; }
+    save(this, options, next);
   });
   schema.post('find', function postFind(doc, next) {
-    if (authIsDisabled(this.options)) { return next(); }
-    return find(this, doc, next);
+    if (authIsDisabled(this.options)) { next(); return; }
+    find(this, doc, next);
   });
   schema.post('findOne', function postFindOne(doc, next) {
-    if (authIsDisabled(this.options)) { return next(); }
-    return find(this, doc, next);
+    if (authIsDisabled(this.options)) { next(); return; }
+    find(this, doc, next);
   });
   schema.pre('update', function preUpdate(next) {
-    if (authIsDisabled(this.options)) { return next(); }
-    return update(this, next);
+    if (authIsDisabled(this.options)) { next(); return; }
+    update(this, next);
   });
   schema.pre('findOneAndUpdate', function preFindOneAndUpdate(next) {
-    if (authIsDisabled(this.options)) { return next(); }
-    return update(this, next);
+    if (authIsDisabled(this.options)) { next(); return; }
+    update(this, next);
   });
 
   schema.query.setAuthLevel = function setAuthLevel(authLevel) {
@@ -133,7 +141,7 @@ module.exports = (schema) => {
     return this;
   };
 
-  schema.statics.canCreate = function canCreate(options) {
-    return hasPermission(this.schema, options, 'create');
+  schema.statics.canCreate = async function canCreate(options) {
+    return await hasPermission(this.schema, options, 'create');
   };
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const {
+  resolveAuthLevel,
   getAuthorizedFields,
   hasPermission,
   authIsDisabled,
@@ -10,77 +11,65 @@ const {
 const PermissionDeniedError = require('./lib/PermissionDeniedError');
 
 module.exports = (schema) => {
-  async function save(doc, options, next) {
-    if (doc.isNew && !await hasPermission(schema, options, 'create', doc)) {
-      next(new PermissionDeniedError('create'));
-      return;
+  async function save(doc, options) {
+    const authLevels = await resolveAuthLevel(schema, options, doc);
+    if (doc.isNew && !hasPermission(schema, authLevels, 'create')) {
+      throw new PermissionDeniedError('create');
     }
 
-    const authorizedFields = await getAuthorizedFields(schema, options, 'write', doc);
+    const authorizedFields = getAuthorizedFields(schema, authLevels, 'write');
     const modifiedPaths = doc.modifiedPaths();
     const discrepancies = _.difference(modifiedPaths, authorizedFields);
 
     if (discrepancies.length > 0) {
-      next(new PermissionDeniedError('write', discrepancies));
-      return;
+      throw new PermissionDeniedError('write', discrepancies);
     }
-
-    next();
   }
 
-  async function removeQuery(query, next) {
-    if (!await hasPermission(schema, query.options, 'remove')) {
-      next(new PermissionDeniedError('remove'));
-      return;
+  async function removeQuery(query) {
+    const authLevels = await resolveAuthLevel(schema, query.options);
+    if (!hasPermission(schema, authLevels, 'remove')) {
+      throw new PermissionDeniedError('remove');
     }
-
-    next();
-    return;
   }
 
-  async function removeDoc(doc, options, next) {
-    if (!await hasPermission(schema, options, 'remove', doc)) {
-      next(new PermissionDeniedError('remove'));
-      return;
+  async function removeDoc(doc, options) {
+    const authLevels = await resolveAuthLevel(schema, options, doc);
+    if (!hasPermission(schema, authLevels, 'remove')) {
+      throw new PermissionDeniedError('remove');
     }
-
-    next();
-    return;
   }
 
-  async function find(query, docs, next) {
-    const sanitizedResult = await sanitizeDocumentList(schema, query.options, docs);
-
-    next(null, sanitizedResult);
+  async function find(query, docs) {
+    return sanitizeDocumentList(schema, query.options, docs);
   }
 
-  async function update(query, next) {
+  async function update(query) {
+    const authLevels = await resolveAuthLevel(schema, query.options);
     // If this is an upsert, you'll need the create permission
     // TODO add some tests for the upset case
     if (
       query.options
       && query.options.upsert
-      && !await hasPermission(schema, query.options, 'create')
+      && !hasPermission(schema, authLevels, 'create')
     ) {
-      next(new PermissionDeniedError('create'));
-      return;
+      throw new PermissionDeniedError('create');
     }
 
-    const authorizedFields = await getAuthorizedFields(schema, query.options, 'write');
+    const authorizedFields = getAuthorizedFields(schema, authLevels, 'write');
 
     // check to see if the group is trying to update a field it does not have permission to
     const modifiedPaths = getUpdatePaths(query._update);
     const discrepancies = _.difference(modifiedPaths, authorizedFields);
     if (discrepancies.length > 0) {
-      next(new PermissionDeniedError('write', discrepancies));
-      return;
+      throw new PermissionDeniedError('write', discrepancies);
     }
 
     // TODO handle the overwrite option
     // TODO handle Model.updateMany
 
     // Detect which fields can be returned if 'new: true' is set
-    const authorizedReturnFields = await getAuthorizedFields(schema, query.options, 'read');
+    const authorizedReturnFields = getAuthorizedFields(schema, authLevels, 'read');
 
     // create a sanitizedReturnFields object that will be used to return only the fields that a
     // group has access to read
@@ -91,8 +80,6 @@ module.exports = (schema) => {
       }
     });
     query._fields = sanitizedReturnFields;
-
-    next();
   }
 
   // Find paths with permissioned schemas and store those so deep checks can be done
@@ -105,35 +92,44 @@ module.exports = (schema) => {
     }
   });
 
-  schema.pre('findOneAndRemove', function preFindOneAndRemove(next) {
-    if (authIsDisabled(this.options)) { next(); return; }
-    removeQuery(this, next);
+  // PRE- DOCUMENT hooks
+  // We do a bit of manual promise handling for these two (pre-save and pre-remove)
+  // because the only way to get mongoose to pass in an options dict on document middleware
+  // is to have arguments to the middleware function. If we have arguments, mongoose
+  // assume we want to use a `next()` function. FML
+  schema.pre('save', function preSave(next, options) {
+    if (authIsDisabled(options)) { return next(); }
+    return save(this, options)
+      .then(() => next())
+      .catch(next);
   });
   // TODO, WTF, how to prevent someone from Model.find().remove().exec(); That doesn't
   // fire any remove hooks. Does it fire a find hook?
   schema.pre('remove', function preRemove(next, options) {
-    if (authIsDisabled(options)) { next(); return; }
-    removeDoc(this, options, next);
+    if (authIsDisabled(options)) { return next(); }
+    return removeDoc(this, options)
+      .then(() => next())
+      .catch(next);
   });
-  schema.pre('save', function preSave(next, options) {
-    if (authIsDisabled(options)) { next(); return; }
-    save(this, options, next);
+  schema.pre('findOneAndRemove', async function preFindOneAndRemove() {
+    if (authIsDisabled(this.options)) { return; }
+    await removeQuery(this);
   });
-  schema.post('find', function postFind(doc, next) {
-    if (authIsDisabled(this.options)) { next(); return; }
-    find(this, doc, next);
+  schema.post('find', async function postFind(docs) {
+    if (authIsDisabled(this.options)) { return; }
+    await find(this, docs);
   });
-  schema.post('findOne', function postFindOne(doc, next) {
-    if (authIsDisabled(this.options)) { next(); return; }
-    find(this, doc, next);
+  schema.post('findOne', async function postFindOne(doc) {
+    if (authIsDisabled(this.options)) { return; }
+    await find(this, doc);
   });
-  schema.pre('update', function preUpdate(next) {
-    if (authIsDisabled(this.options)) { next(); return; }
-    update(this, next);
+  schema.pre('update', async function preUpdate() {
+    if (authIsDisabled(this.options)) { return; }
+    await update(this);
   });
-  schema.pre('findOneAndUpdate', function preFindOneAndUpdate(next) {
-    if (authIsDisabled(this.options)) { next(); return; }
-    update(this, next);
+  schema.pre('findOneAndUpdate', async function preFindOneAndUpdate() {
+    if (authIsDisabled(this.options)) { return; }
+    await update(this);
   });
 
   schema.query.setAuthLevel = function setAuthLevel(authLevel) {
@@ -141,7 +137,10 @@ module.exports = (schema) => {
     return this;
   };
 
+  // TODO add tests for this function
   schema.statics.canCreate = async function canCreate(options) {
-    return await hasPermission(this.schema, options, 'create');
+    // Check just the blank document since nothing exists yet
+    const authLevels = await resolveAuthLevel(schema, options, {});
+    return hasPermission(this.schema, authLevels, 'create');
   };
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,50 +17,67 @@ async function resolveAuthLevel(schema, options, doc) {
   // in defaults.
   authLevels.push('defaults');
 
+  return cleanAuthLevels(schema, authLevels);
+}
+
+// TODO add tests
+function cleanAuthLevels(schema, authLevels) {
   const perms = schema.permissions || {};
+
   return _.chain(authLevels)
+    .castArray()
     .filter(level => !!perms[level]) // make sure the level in the permissions dict
     .uniq() // get rid of fields mentioned in multiple levels
     .value();
 }
 
-async function getAuthorizedFields(schema, options, action, doc) {
-  const authLevels = await resolveAuthLevel(schema, options, doc);
+function getAuthorizedFields(schema, authLevels, action) {
+  const cleanedLevels = cleanAuthLevels(schema, authLevels);
 
-  return _.chain(authLevels)
+  return _.chain(cleanedLevels)
     .flatMap(level => schema.permissions[level][action])
     .filter(path => schema.pathType(path) !== 'adhocOrUndefined') // ensure fields are in schema
     .uniq() // dropping duplicates
     .value();
 }
 
-async function hasPermission(schema, options, action, doc) {
-  const authLevels = await resolveAuthLevel(schema, options, doc);
+function hasPermission(schema, authLevels, action) {
   const perms = schema.permissions || {};
 
   // look for any permissions setting for this action that is set to true (for these authLevels)
-  return _.some(authLevels, level => perms[level][action]);
+  const cleanedLevels = cleanAuthLevels(schema, authLevels);
+  return _.some(cleanedLevels, level => perms[level][action])
 }
 
 function authIsDisabled(options) {
   return options && options.authLevel === false;
 }
 
-async function embedPermissions(schema, options, doc) {
+function embedPermissions(schema, options, authLevels, doc) {
   if (!options || !options.permissions) { return; }
 
   const permsKey = options.permissions === true ? 'permissions' : options.permissions;
   doc[permsKey] = {
-    read: await getAuthorizedFields(schema, options, 'read', doc),
-    write: await getAuthorizedFields(schema, options, 'write', doc),
-    remove: await hasPermission(schema, options, 'remove', doc),
+    read: getAuthorizedFields(schema, authLevels, 'read'),
+    write: getAuthorizedFields(schema, authLevels, 'write'),
+    remove: hasPermission(schema, authLevels, 'remove'),
   };
 }
 
 async function sanitizeDocument(schema, options, doc) {
-  const authorizedFields = await getAuthorizedFields(schema, options, 'read', doc);
+  if (!doc) { return; }
 
-  if (!doc || authorizedFields.length === 0) { return false; }
+  // If there are subschemas that need to be authorized, store a reference to the top
+  // level doc so they have context when doing their authorization checks
+  const optionAddition = {};
+  if (!options.originalDoc && !_.isEmpty(schema.pathsWithPermissionedSchemas)) {
+    optionAddition.authPayload = { originalDoc: doc };
+  }
+  const docOptions = _.merge({}, options, optionAddition);
+
+
+  const authLevels = await resolveAuthLevel(schema, docOptions, doc);
+  const authorizedFields = getAuthorizedFields(schema, authLevels, 'read');
 
   // Check to see if group has the permission to see the fields that came back.
   // We must edit the document in place to maintain the right reference
@@ -71,10 +88,6 @@ async function sanitizeDocument(schema, options, doc) {
   // Mongoose Document.
   const innerDoc = doc._doc || doc;
   const newDoc = _.pick(innerDoc, authorizedFields);
-  if (_.isEmpty(newDoc)) {
-    // There are no fields that can be seen, just return now
-    return false;
-  }
 
   // Empty out the object so we can put in other the paths that were `_.pick`ed
   // Then copy back only the info the user is allowed to see
@@ -97,36 +110,36 @@ async function sanitizeDocument(schema, options, doc) {
   });
 
   // Check to see if we're going to be inserting the permissions info
-  if (options.permissions) {
-    await embedPermissions(schema, options, doc);
-  }
+  embedPermissions(schema, docOptions, authLevels, doc);
 
   // Apply the rules down one level if there are any path specific permissions
-  await Promise.all(_.map(schema.pathsWithPermissionedSchemas, async (path, subSchema) => {
-    if (innerDoc[path]) {
-      // eslint-disable-next-line no-use-before-define
-      innerDoc[path] = await sanitizeDocumentList(subSchema, options, innerDoc[path]);
-    }
-  }));
+  const subDocSanitationPromises = _.map(
+    schema.pathsWithPermissionedSchemas,
+    async (path, subSchema) => {
+      if (innerDoc[path]) {
+        // eslint-disable-next-line no-use-before-define
+        innerDoc[path] = await sanitizeDocumentList(subSchema, docOptions, innerDoc[path]);
+      }
+    },
+  );
 
-  return doc;
+  await Promise.all(subDocSanitationPromises);
 }
 
 async function sanitizeDocumentList(schema, options, docs) {
   const multi = _.isArrayLike(docs);
-  const docList = _.castArray(docs);
-  const sanitizeAndAddOptions = (doc) => {
-    const upgradedOptions = _.isEmpty(schema.pathsWithPermissionedSchemas)
-      ? options
-      : _.merge({}, options, { authPayload: { originalDoc: doc } });
-    return sanitizeDocument(schema, upgradedOptions, doc);
-  };
 
-  const filteredResult = (
-    await Promise.all(docList.map(sanitizeAndAddOptions))
-  ).filter(doc => !doc);
+  if (!multi) {
+    sanitizeDocument(schema, options, docs);
+    return;
+  }
 
-  return multi ? (filteredResult) : filteredResult[0];
+  const sanitizationPromises = docs.map(
+    doc => sanitizeDocument(schema, options, doc),
+  );
+  await Promise.all(sanitizationPromises);
+
+  _.remove(docs, doc => _.isEmpty(doc._doc || doc));
 }
 
 function getUpdatePaths(updates) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,16 +4,14 @@ async function resolveAuthLevel(schema, options, doc) {
   // Look into options the options and try to find authLevels. Always prefer to take
   // authLevels from the direct authLevel option as opposed to the computed
   // ones from getAuthLevel in the schema object.
-  let authLevelsIn = [];
+  let authLevels = [];
   if (options) {
     if (options.authLevel) {
-      authLevelsIn = options.authLevel;
+      authLevels = _.castArray(options.authLevel);
     } else if (typeof schema.getAuthLevel === 'function') {
-      authLevelsIn = schema.getAuthLevel(options.authPayload, doc);
+      authLevels = _.castArray(await schema.getAuthLevel(options.authPayload, doc));
     }
   }
-
-  const authLevels = _.castArray(await Promise.resolve(authLevelsIn));
 
   // Add `defaults` to the list of levels since you should always be able to do what's specified
   // in defaults.
@@ -117,18 +115,18 @@ async function sanitizeDocument(schema, options, doc) {
 async function sanitizeDocumentList(schema, options, docs) {
   const multi = _.isArrayLike(docs);
   const docList = _.castArray(docs);
+  const sanitizeAndAddOptions = (doc) => {
+    const upgradedOptions = _.isEmpty(schema.pathsWithPermissionedSchemas)
+      ? options
+      : _.merge({}, options, { authPayload: { originalDoc: doc } });
+    return sanitizeDocument(schema, upgradedOptions, doc);
+  };
 
-  const filteredResult = _.chain(await Promise.all(_.map(docList, async (doc) => {
-      const upgradedOptions = _.isEmpty(schema.pathsWithPermissionedSchemas)
-        ? options
-        : _.merge({}, options, { authPayload: { originalDoc: doc } });
+  const filteredResult = (
+    await Promise.all(docList.map(sanitizeAndAddOptions))
+  ).filter(doc => !doc);
 
-      return await sanitizeDocument(schema, upgradedOptions, doc);
-    })))
-    .filter(docList)
-    .value();
-
-  return multi ? Promise.all(filteredResult) : filteredResult[0];
+  return multi ? (filteredResult) : filteredResult[0];
 }
 
 function getUpdatePaths(updates) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,17 +1,20 @@
 const _ = require('lodash');
 
-function resolveAuthLevel(schema, options, doc) {
+async function resolveAuthLevel(schema, options, doc) {
   // Look into options the options and try to find authLevels. Always prefer to take
   // authLevels from the direct authLevel option as opposed to the computed
   // ones from getAuthLevel in the schema object.
-  let authLevels = [];
+  let authLevelsIn = [];
   if (options) {
     if (options.authLevel) {
-      authLevels = _.castArray(options.authLevel);
+      authLevelsIn = options.authLevel;
     } else if (typeof schema.getAuthLevel === 'function') {
-      authLevels = _.castArray(schema.getAuthLevel(options.authPayload, doc));
+      authLevelsIn = schema.getAuthLevel(options.authPayload, doc);
     }
   }
+
+  const authLevels = _.castArray(await Promise.resolve(authLevelsIn));
+
   // Add `defaults` to the list of levels since you should always be able to do what's specified
   // in defaults.
   authLevels.push('defaults');
@@ -23,8 +26,8 @@ function resolveAuthLevel(schema, options, doc) {
     .value();
 }
 
-function getAuthorizedFields(schema, options, action, doc) {
-  const authLevels = resolveAuthLevel(schema, options, doc);
+async function getAuthorizedFields(schema, options, action, doc) {
+  const authLevels = await resolveAuthLevel(schema, options, doc);
 
   return _.chain(authLevels)
     .flatMap(level => schema.permissions[level][action])
@@ -33,8 +36,8 @@ function getAuthorizedFields(schema, options, action, doc) {
     .value();
 }
 
-function hasPermission(schema, options, action, doc) {
-  const authLevels = resolveAuthLevel(schema, options, doc);
+async function hasPermission(schema, options, action, doc) {
+  const authLevels = await resolveAuthLevel(schema, options, doc);
   const perms = schema.permissions || {};
 
   // look for any permissions setting for this action that is set to true (for these authLevels)
@@ -45,21 +48,21 @@ function authIsDisabled(options) {
   return options && options.authLevel === false;
 }
 
-function embedPermissions(schema, options, doc) {
+async function embedPermissions(schema, options, doc) {
   if (!options || !options.permissions) { return; }
 
   const permsKey = options.permissions === true ? 'permissions' : options.permissions;
   doc[permsKey] = {
-    read: getAuthorizedFields(schema, options, 'read', doc),
-    write: getAuthorizedFields(schema, options, 'write', doc),
-    remove: hasPermission(schema, options, 'remove', doc),
+    read: await getAuthorizedFields(schema, options, 'read', doc),
+    write: await getAuthorizedFields(schema, options, 'write', doc),
+    remove: await hasPermission(schema, options, 'remove', doc),
   };
 }
 
-function sanitizeDocument(schema, options, doc) {
-  const authorizedFields = getAuthorizedFields(schema, options, 'read', doc);
+async function sanitizeDocument(schema, options, doc) {
+  const authorizedFields = await getAuthorizedFields(schema, options, 'read', doc);
 
-  if (!doc || getAuthorizedFields.length === 0) { return false; }
+  if (!doc || authorizedFields.length === 0) { return false; }
 
   // Check to see if group has the permission to see the fields that came back.
   // We must edit the document in place to maintain the right reference
@@ -97,36 +100,35 @@ function sanitizeDocument(schema, options, doc) {
 
   // Check to see if we're going to be inserting the permissions info
   if (options.permissions) {
-    embedPermissions(schema, options, doc);
+    await embedPermissions(schema, options, doc);
   }
 
   // Apply the rules down one level if there are any path specific permissions
-  _.each(schema.pathsWithPermissionedSchemas, (path, subSchema) => {
+  await Promise.all(_.map(schema.pathsWithPermissionedSchemas, async (path, subSchema) => {
     if (innerDoc[path]) {
       // eslint-disable-next-line no-use-before-define
-      innerDoc[path] = sanitizeDocumentList(subSchema, options, innerDoc[path]);
+      innerDoc[path] = await sanitizeDocumentList(subSchema, options, innerDoc[path]);
     }
-  });
+  }));
 
   return doc;
 }
 
-function sanitizeDocumentList(schema, options, docs) {
+async function sanitizeDocumentList(schema, options, docs) {
   const multi = _.isArrayLike(docs);
   const docList = _.castArray(docs);
 
-  const filteredResult = _.chain(docList)
-    .map((doc) => {
+  const filteredResult = _.chain(await Promise.all(_.map(docList, async (doc) => {
       const upgradedOptions = _.isEmpty(schema.pathsWithPermissionedSchemas)
         ? options
         : _.merge({}, options, { authPayload: { originalDoc: doc } });
 
-      return sanitizeDocument(schema, upgradedOptions, doc);
-    })
+      return await sanitizeDocument(schema, upgradedOptions, doc);
+    })))
     .filter(docList)
     .value();
 
-  return multi ? filteredResult : filteredResult[0];
+  return multi ? Promise.all(filteredResult) : filteredResult[0];
 }
 
 function getUpdatePaths(updates) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,6 +9,12 @@ function resolveAuthLevel(schema, options, doc) {
     if (options.authLevel) {
       authLevels = _.castArray(options.authLevel);
     } else if (typeof schema.getAuthLevel === 'function') {
+      if (!options.authPayload) {
+        throw new Error('An `authPayload` must exist with a `getAuthLevel` method.');
+      }
+      if (!doc) {
+        throw new Error('This type of query is not compatible with using a getAuthLevel method.');
+      }
       authLevels = _.castArray(schema.getAuthLevel(options.authPayload, doc));
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-authorization",
-  "version": "0.1.1",
+  "version": "2.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-import": "2.9.0",
     "mongodb": "^3.0.1",
     "mongodb-runner": "3.6.1",
-    "mongoose": "^4.13.9",
+    "mongoose": "^5.0.0",
     "nodeunit": "^0.11.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash": "^4.17.5"
   },
   "peerDependencies": {
-    "mongoose": "^4.5.0"
+    "mongoose": "^5.0.0"
   },
   "devDependencies": {
     "eslint": "4.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mongoose-authorization",
-  "version": "2.0.0-alpha.1",
+  "name": "mongoose-authz",
+  "version": "1.0.0-alpha.1",
   "engines": {
     "node": ">=8.2.1"
   },
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/352Media/mongoose-authorization.git"
+    "url": "git+https://github.com/devcolor/mongoose-authz.git"
   },
   "keywords": [
     "mongoose",
@@ -28,12 +28,12 @@
     "mongo permissions",
     "mongodb permissions"
   ],
-  "author": "352inc <devops@352inc.com> (http://352inc.com)",
+  "author": "Makinde Adeagbo",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/352Media/mongoose-authorization/issues"
+    "url": "https://github.com/devcolor/mongoose-authz/issues"
   },
-  "homepage": "https://github.com/352Media/mongoose-authorization#readme",
+  "homepage": "https://github.com/devcolor/mongoose-authz#readme",
   "dependencies": {
     "lodash": "^4.17.5"
   },

--- a/test/car.schema.js
+++ b/test/car.schema.js
@@ -25,9 +25,6 @@ const carSchema = new mongoose.Schema({
  * Make sure you add this before compiling your model
  */
 carSchema.permissions = {
-  defaults: {
-    read: ['_id', 'make', 'model', 'year'],
-  },
   maker: {
     write: ['make', 'model', 'year'],
     remove: true,

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -119,7 +119,7 @@ module.exports = {
     },
     'from document getAuthLevel': async (test) => {
       test.deepEqual(
-        resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'admin' } }, { foo: 1 }),
+        await resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'admin' } }, { foo: 1 }),
         ['admin', 'defaults'],
       );
       test.deepEqual(
@@ -131,7 +131,7 @@ module.exports = {
         ['admin', 'defaults'],
       );
       test.deepEqual(
-        await resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'self' } }),
+        await resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'self' } }, {}),
         ['self', 'defaults'],
       );
       test.done();

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -141,76 +141,71 @@ module.exports = {
       test.done();
     },
   },
-  async getAuthorizedFields(test) {
+  getAuthorizedFields(test) {
     test.deepEqual(
-      await getAuthorizedFields(bareBonesSchema, { authLevel: 'foobar' }, 'read'),
+      getAuthorizedFields(bareBonesSchema, 'foobar', 'read'),
       [],
     );
     test.deepEqual(
-      (await getAuthorizedFields(goodSchema, { authLevel: 'foobar' }, 'read')).sort(),
+      getAuthorizedFields(goodSchema, ['defaults', 'foobar'], 'read').sort(),
       ['_id', 'name'].sort(),
     );
     test.deepEqual(
-      (await getAuthorizedFields(goodSchema, { authLevel: 'admin' }, 'read')).sort(),
+      getAuthorizedFields(goodSchema, ['defaults', 'admin'], 'read').sort(),
       ['_id', 'name', 'address', 'phone', 'birthday'].sort(),
     );
     test.deepEqual(
-      (await getAuthorizedFields(goodSchema, { authLevel: 'stranger' }, 'read')).sort(),
+      getAuthorizedFields(goodSchema, ['defaults', 'stranger'], 'read').sort(),
       ['_id', 'name'].sort(),
     );
     test.deepEqual(
-      (await getAuthorizedFields(goodSchema, { authLevel: ['self', 'admin'] }, 'read')).sort(),
+      getAuthorizedFields(goodSchema, ['defaults', 'self', 'admin'], 'read').sort(),
       ['_id', 'name', 'address', 'phone', 'birthday'].sort(),
     );
     test.deepEqual(
-      (await getAuthorizedFields(goodSchema, { authLevel: 'self' }, 'write')).sort(),
+      getAuthorizedFields(goodSchema, ['defaults', 'self'], 'write').sort(),
       ['address', 'phone'].sort(),
     );
     test.deepEqual(
-      await getAuthorizedFields(bareBonesSchema, { authLevel: 'admin' }, 'write'),
+      getAuthorizedFields(bareBonesSchema, 'admin', 'write'),
       [],
     );
     test.deepEqual(
-      (await getAuthorizedFields(goodSchema, { authLevel: 'hasVirtuals' }, 'read')).sort(),
+      getAuthorizedFields(goodSchema, ['defaults', 'hasVirtuals'], 'read').sort(),
       ['_id', 'name', 'virtual_name'].sort(),
       'virtuals should be included in the list of fields',
     );
     test.deepEqual(
-      (await getAuthorizedFields(goodSchema, { authLevel: 'nested_top' }, 'read')).sort(),
+      getAuthorizedFields(goodSchema, ['defaults', 'nested_top'], 'read').sort(),
       ['_id', 'name', 'nested'].sort(),
       'top level nested field should be ok as authorized field',
     );
     test.deepEqual(
-      (await getAuthorizedFields(goodSchema, { authLevel: 'nested_deep' }, 'read')).sort(),
+      getAuthorizedFields(goodSchema, ['defaults', 'nested_deep'], 'read').sort(),
       ['_id', 'name', 'nested.thing'].sort(),
       'deeply nested field should be ok as authorized field',
     );
 
     test.done();
   },
-  async hasPermission(test) {
+  hasPermission(test) {
     test.equal(
-      await hasPermission(bareBonesSchema, undefined, 'create'),
+      hasPermission(bareBonesSchema, undefined, 'create'),
       false,
       'should return false when no options provided',
     );
     test.equal(
-      await hasPermission(bareBonesSchema, {}, 'create'),
+      hasPermission(bareBonesSchema, [], 'create'),
       false,
       'should return false when no permissions exist',
     );
     test.equal(
-      await hasPermission(goodSchema, {}, 'create'),
-      false,
-      'default write permission not respected when no authLevel specified',
-    );
-    test.equal(
-      await hasPermission(goodSchema, {}, 'create'),
+      hasPermission(goodSchema, [], 'create'),
       false,
       'should return false when no permission has been set for the action',
     );
     test.equal(
-      await hasPermission(goodSchema, { authLevel: 'admin' }, 'create'),
+      hasPermission(goodSchema, ['default', 'admin'], 'create'),
       true,
       'should return true when an AuthLevel says so, despite default',
     );

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -119,10 +119,6 @@ module.exports = {
     },
     'from document getAuthLevel': (test) => {
       test.deepEqual(
-        resolveAuthLevel(goodSchema, {}, { foo: 1 }),
-        ['defaults'],
-      );
-      test.deepEqual(
         resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'admin' } }, { foo: 1 }),
         ['admin', 'defaults'],
       );
@@ -134,10 +130,26 @@ module.exports = {
         resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'self' }, authLevel: 'admin' }, { foo: 1 }),
         ['admin', 'defaults'],
       );
-      test.deepEqual(
-        resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'self' } }),
-        ['self', 'defaults'],
-      );
+      test.done();
+    },
+    'missing authPayload': (test) => {
+      test.expect(1);
+      try {
+        resolveAuthLevel(goodSchema, {}, {});
+      } catch(err) {
+        test.ok(err);
+      }
+
+      test.done();
+    },
+    'missing doc': (test) => {
+      test.expect(1);
+      try {
+        resolveAuthLevel(goodSchema, { authPayload: 'foo' }, false);
+      } catch(err) {
+        test.ok(err);
+      }
+
       test.done();
     },
   },
@@ -198,16 +210,6 @@ module.exports = {
       hasPermission(bareBonesSchema, {}, 'create'),
       false,
       'should return false when no permissions exist',
-    );
-    test.equal(
-      hasPermission(goodSchema, {}, 'create'),
-      false,
-      'default write permission not respected when no authLevel specified',
-    );
-    test.equal(
-      hasPermission(goodSchema, {}, 'create'),
-      false,
-      'should return false when no permission has been set for the action',
     );
     test.equal(
       hasPermission(goodSchema, { authLevel: 'admin' }, 'create'),

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -67,150 +67,150 @@ const queryOpt = { authLevel: 'admin' };
 
 module.exports = {
   resolveAuthLevel: {
-    'single in query options': (test) => {
+    'single in query options': async (test) => {
       // Single Auth level in query options
       test.deepEqual(
-        resolveAuthLevel(goodSchema, queryOpt),
+        await resolveAuthLevel(goodSchema, queryOpt),
         ['admin', 'defaults'],
       );
 
       test.done();
     },
-    'unknown in query options': (test) => {
+    'unknown in query options': async (test) => {
       test.deepEqual(
-        resolveAuthLevel(goodSchema, { authLevel: 'foobar' }),
+        await resolveAuthLevel(goodSchema, { authLevel: 'foobar' }),
         ['defaults'],
       );
       test.deepEqual(
-        resolveAuthLevel(goodSchema, { authLevel: ['foobar', 'self'] }),
+        await resolveAuthLevel(goodSchema, { authLevel: ['foobar', 'self'] }),
         ['self', 'defaults'],
       );
       test.deepEqual(
-        resolveAuthLevel(bareBonesSchema, { authLevel: ['foobar'] }),
+        await resolveAuthLevel(bareBonesSchema, { authLevel: ['foobar'] }),
         [],
       );
       test.deepEqual(
-        resolveAuthLevel(bareBonesSchema, { authLevel: 'default' }),
-        [],
-      );
-      test.done();
-    },
-    'bad schema': (test) => {
-      test.deepEqual(
-        resolveAuthLevel(emptySchema, { authLevel: 'admin' }),
+        await resolveAuthLevel(bareBonesSchema, { authLevel: 'default' }),
         [],
       );
       test.done();
     },
-    'multiple in query options': (test) => {
+    'bad schema': async (test) => {
       test.deepEqual(
-        resolveAuthLevel(goodSchema, { authLevel: ['self', 'admin'] }),
+        await resolveAuthLevel(emptySchema, { authLevel: 'admin' }),
+        [],
+      );
+      test.done();
+    },
+    'multiple in query options': async (test) => {
+      test.deepEqual(
+        await resolveAuthLevel(goodSchema, { authLevel: ['self', 'admin'] }),
         ['self', 'admin', 'defaults'],
       );
       test.deepEqual(
-        resolveAuthLevel(goodSchema, { authLevel: ['defaults'] }),
+        await resolveAuthLevel(goodSchema, { authLevel: ['defaults'] }),
         ['defaults'],
       );
       test.deepEqual(
-        resolveAuthLevel(goodSchema, { authLevel: ['self', 'admin', 'self', 'default', 'admin'] }),
+        await resolveAuthLevel(goodSchema, { authLevel: ['self', 'admin', 'self', 'default', 'admin'] }),
         ['self', 'admin', 'defaults'],
       );
       test.done();
     },
-    'from document getAuthLevel': (test) => {
+    'from document getAuthLevel': async (test) => {
       test.deepEqual(
-        resolveAuthLevel(goodSchema, {}, { foo: 1 }),
+        await resolveAuthLevel(goodSchema, {}, { foo: 1 }),
         ['defaults'],
       );
       test.deepEqual(
-        resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'admin' } }, { foo: 1 }),
+        await resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'admin' } }, { foo: 1 }),
         ['admin', 'defaults'],
       );
       test.deepEqual(
-        resolveAuthLevel(goodSchema, { authPayload: { authLevel: false } }, { foo: 1 }),
+        await resolveAuthLevel(goodSchema, { authPayload: { authLevel: false } }, { foo: 1 }),
         ['defaults'],
       );
       test.deepEqual(
-        resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'self' }, authLevel: 'admin' }, { foo: 1 }),
+        await resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'self' }, authLevel: 'admin' }, { foo: 1 }),
         ['admin', 'defaults'],
       );
       test.deepEqual(
-        resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'self' } }),
+        await resolveAuthLevel(goodSchema, { authPayload: { authLevel: 'self' } }),
         ['self', 'defaults'],
       );
       test.done();
     },
   },
-  getAuthorizedFields(test) {
+  async getAuthorizedFields(test) {
     test.deepEqual(
-      getAuthorizedFields(bareBonesSchema, { authLevel: 'foobar' }, 'read'),
+      await getAuthorizedFields(bareBonesSchema, { authLevel: 'foobar' }, 'read'),
       [],
     );
     test.deepEqual(
-      getAuthorizedFields(goodSchema, { authLevel: 'foobar' }, 'read').sort(),
+      (await getAuthorizedFields(goodSchema, { authLevel: 'foobar' }, 'read')).sort(),
       ['_id', 'name'].sort(),
     );
     test.deepEqual(
-      getAuthorizedFields(goodSchema, { authLevel: 'admin' }, 'read').sort(),
+      (await getAuthorizedFields(goodSchema, { authLevel: 'admin' }, 'read')).sort(),
       ['_id', 'name', 'address', 'phone', 'birthday'].sort(),
     );
     test.deepEqual(
-      getAuthorizedFields(goodSchema, { authLevel: 'stranger' }, 'read').sort(),
+      (await getAuthorizedFields(goodSchema, { authLevel: 'stranger' }, 'read')).sort(),
       ['_id', 'name'].sort(),
     );
     test.deepEqual(
-      getAuthorizedFields(goodSchema, { authLevel: ['self', 'admin'] }, 'read').sort(),
+      (await getAuthorizedFields(goodSchema, { authLevel: ['self', 'admin'] }, 'read')).sort(),
       ['_id', 'name', 'address', 'phone', 'birthday'].sort(),
     );
     test.deepEqual(
-      getAuthorizedFields(goodSchema, { authLevel: 'self' }, 'write').sort(),
+      (await getAuthorizedFields(goodSchema, { authLevel: 'self' }, 'write')).sort(),
       ['address', 'phone'].sort(),
     );
     test.deepEqual(
-      getAuthorizedFields(bareBonesSchema, { authLevel: 'admin' }, 'write'),
+      await getAuthorizedFields(bareBonesSchema, { authLevel: 'admin' }, 'write'),
       [],
     );
     test.deepEqual(
-      getAuthorizedFields(goodSchema, { authLevel: 'hasVirtuals' }, 'read').sort(),
+      (await getAuthorizedFields(goodSchema, { authLevel: 'hasVirtuals' }, 'read')).sort(),
       ['_id', 'name', 'virtual_name'].sort(),
       'virtuals should be included in the list of fields',
     );
     test.deepEqual(
-      getAuthorizedFields(goodSchema, { authLevel: 'nested_top' }, 'read').sort(),
+      (await getAuthorizedFields(goodSchema, { authLevel: 'nested_top' }, 'read')).sort(),
       ['_id', 'name', 'nested'].sort(),
       'top level nested field should be ok as authorized field',
     );
     test.deepEqual(
-      getAuthorizedFields(goodSchema, { authLevel: 'nested_deep' }, 'read').sort(),
+      (await getAuthorizedFields(goodSchema, { authLevel: 'nested_deep' }, 'read')).sort(),
       ['_id', 'name', 'nested.thing'].sort(),
       'deeply nested field should be ok as authorized field',
     );
 
     test.done();
   },
-  hasPermission(test) {
+  async hasPermission(test) {
     test.equal(
-      hasPermission(bareBonesSchema, undefined, 'create'),
+      await hasPermission(bareBonesSchema, undefined, 'create'),
       false,
       'should return false when no options provided',
     );
     test.equal(
-      hasPermission(bareBonesSchema, {}, 'create'),
+      await hasPermission(bareBonesSchema, {}, 'create'),
       false,
       'should return false when no permissions exist',
     );
     test.equal(
-      hasPermission(goodSchema, {}, 'create'),
+      await hasPermission(goodSchema, {}, 'create'),
       false,
       'default write permission not respected when no authLevel specified',
     );
     test.equal(
-      hasPermission(goodSchema, {}, 'create'),
+      await hasPermission(goodSchema, {}, 'create'),
       false,
       'should return false when no permission has been set for the action',
     );
     test.equal(
-      hasPermission(goodSchema, { authLevel: 'admin' }, 'create'),
+      await hasPermission(goodSchema, { authLevel: 'admin' }, 'create'),
       true,
       'should return true when an AuthLevel says so, despite default',
     );


### PR DESCRIPTION
Hey @brysgo , I took your first few commits and then added one. The main change is that the code only calls `resolveAuthLevel` once per query/operation. I think this'll get rid of the need to memoize/optimize (well, the refactor is an optimization). It should seem very familiar.